### PR TITLE
Heap elimination, minor optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ impl ParserHandler for MyHandler {
     // Let's try to handle headers: the following callback function will be
     // called when parser founds a header in the HTTP stream.
 
-    fn on_header_field(&self, header: &String) -> Option<u16> {
+    fn on_header_field(&self, header: &[u8]) -> Option<u16> {
         // Print the received header key
         println!("{}: ", header);
 
@@ -58,7 +58,7 @@ impl ParserHandler for MyHandler {
     }
 
     // And let's print the header values in a similar vein:
-    fn on_header_value(&self, value: &String) -> Option<u16> {
+    fn on_header_value(&self, value: &[u8]) -> Option<u16> {
         println!("\t {}", value);
         None
     }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,49 @@
+#![feature(test)]
+
+extern crate test;
+extern crate http_muncher;
+
+use test::Bencher;
+
+use http_muncher::{ParserHandler, Parser};
+
+#[bench]
+fn bench_request_parser(b: &mut Bencher) {
+    struct TestRequestParser;
+
+    impl ParserHandler for TestRequestParser {
+        fn on_url(&self, url: &[u8]) -> Option<u16> {
+            assert_eq!(b"/say_hello", url);
+            None
+        }
+
+        fn on_header_field(&self, hdr: &[u8]) -> Option<u16> {
+            assert!(hdr == b"Host" || hdr == b"Content-Length");
+            None
+        }
+
+        fn on_header_value(&self, val: &[u8]) -> Option<u16> {
+            assert!(val == b"localhost.localdomain" || val == b"11");
+            None
+        }
+
+        fn on_body(&self, body: &[u8]) -> Option<u16> {
+            assert_eq!(body, b"Hello world");
+            None
+        }
+    }
+
+    let req = b"POST /say_hello HTTP/1.1\r\nContent-Length: 11\r\nHost: localhost.localdomain\r\n\r\nHello world";
+
+    let handler = TestRequestParser;
+
+    b.iter(|| {
+        let mut parser = Parser::request(&handler);
+        let parsed = parser.parse(req);
+
+        assert!(parsed > 0);
+        assert!(!parser.has_error());
+        assert_eq!((1, 1), parser.http_version());
+        assert_eq!("POST", parser.http_method());
+    });
+}


### PR DESCRIPTION
The underlying library provides us fully zero-copy interface, let's use it!
- Heap-allocated string has been replaced by raw slices pointed by the data buffer you own. User can convert it into the owning string easily.
- Methods that return method name, error name and its description now returns static string.
- At last, the version function now returns tuple instead of string, which allows to compare versions without decoding it from a string.

Also this commit should resolve #1.

Benchmarking gives us the following results:
## Before:

running 1 test
test bench_request_parser ... bench:         818 ns/iter (+/- 2)
## After:

running 1 test
test bench_request_parser ... bench:         503 ns/iter (+/- 3)
