### PR TITLE
Changed handlers mutability

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -12,22 +12,22 @@ fn bench_request_parser(b: &mut Bencher) {
     struct TestRequestParser;
 
     impl ParserHandler for TestRequestParser {
-        fn on_url(&self, url: &[u8]) -> Option<u16> {
+        fn on_url(&mut self, url: &[u8]) -> Option<u16> {
             assert_eq!(b"/say_hello", url);
             None
         }
 
-        fn on_header_field(&self, hdr: &[u8]) -> Option<u16> {
+        fn on_header_field(&mut self, hdr: &[u8]) -> Option<u16> {
             assert!(hdr == b"Host" || hdr == b"Content-Length");
             None
         }
 
-        fn on_header_value(&self, val: &[u8]) -> Option<u16> {
+        fn on_header_value(&mut self, val: &[u8]) -> Option<u16> {
             assert!(val == b"localhost.localdomain" || val == b"11");
             None
         }
 
-        fn on_body(&self, body: &[u8]) -> Option<u16> {
+        fn on_body(&mut self, body: &[u8]) -> Option<u16> {
             assert_eq!(body, b"Hello world");
             None
         }
@@ -35,10 +35,10 @@ fn bench_request_parser(b: &mut Bencher) {
 
     let req = b"POST /say_hello HTTP/1.1\r\nContent-Length: 11\r\nHost: localhost.localdomain\r\n\r\nHello world";
 
-    let handler = TestRequestParser;
+    let mut handler = TestRequestParser;
 
     b.iter(|| {
-        let mut parser = Parser::request(&handler);
+        let mut parser = Parser::request(&mut handler);
         let parsed = parser.parse(req);
 
         assert!(parsed > 0);


### PR DESCRIPTION
In the real world streaming parsers must be mutable.

Now it's allowed to change its internal state to be able to track parsing process, cause the parser itself is streaming. For example now it's possible to collect partial headers/body chunks inside the handler for further (or immediate) aggregating or processing.

While parsing you'd probably want to check internal parser's state. Unfortunately Rust's type system forbids us to do so while parser lives, because it now borrows a mutable reference to the handler.

This commit allows us to obtain a mutable reference to the underlying handler while not parsing (probably between parsing iterations). This requires a parser to safe real Handler's type - that's why so many code have been changed.
